### PR TITLE
Fix: placement of error label in FormInput component

### DIFF
--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -76,7 +76,8 @@ const StyledErrorTrigger = styled.div`
     height: 6px;
     border-radius: 100%;
     background-color: ${danger10};
-    top: 17px;
+    top: 50%;
+    transform: translateY(-50%);
     left: -2px;
 `;
 

--- a/src/stories/FormInput.stories.tsx
+++ b/src/stories/FormInput.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import styled, { css } from 'styled-components';
+
+import { FormInput } from '../components/FormInput';
+
+const meta: Meta<typeof FormInput> = {
+    title: 'FormInput',
+    component: FormInput,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {},
+};
+
+const StyledFormInput = styled(FormInput)<{ size: number }>`
+    ${({ size }) => css`
+        font-size: ${size}px;
+
+        & input {
+            font-size: ${size}px;
+        }
+    `}
+`;
+
+export const WithError: Story = {
+    args: {
+        error: {
+            message: 'Error Message',
+        },
+    },
+    render: (props) => (
+        <>
+            <StyledFormInput {...props} size={14} value="font size 14px" />
+            <br />
+            <StyledFormInput {...props} size={32} value="font size 32px" />
+        </>
+    ),
+};


### PR DESCRIPTION
Now error dot always been place by center of field

## PR includes

- [x] Bug Fix

## Related issues

Resolve #207 

## QA Instructions, Screenshots, Recordings
  
<img width="713" alt="image" src="https://github.com/taskany-inc/bricks/assets/7002692/1861559d-37ca-4185-935c-37f98cbc45d4">

You can see example in storybook
