### PR TITLE
Fix ComboBox typings for trigger props

### DIFF
--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, forwardRef } from 'react';
 import styled from 'styled-components';
 import { danger10 } from '@taskany/colors';
 
@@ -213,10 +213,6 @@ export function ComboBoxRenderFunction<T extends HTMLElement>(
     );
 }
 
-export const ComboBox = <T extends HTMLElement>(
-    props: React.PropsWithoutRef<ComboBoxProps<T>> & React.RefAttributes<HTMLDivElement>,
-) => {
-    return React.forwardRef<HTMLDivElement, typeof props>(ComboBoxRenderFunction)(props);
-};
+export const ComboBox = forwardRef<HTMLDivElement, ComboBoxProps<HTMLElement>>(ComboBoxRenderFunction);
 
 export default ComboBox;


### PR DESCRIPTION
Replace generic type for  trigger ref prop for base `HTMLElement`

## PR includes

- [x] Bug Fix

## Related issues

Resolve #257 

## QA Instructions, Screenshots, Recordings
  
Now any trigger ref expect any element those extends of `HTMLElement`