### PR TITLE
Fix ComboBox typings for trigger props

### DIFF
--- a/src/components/ComboBox.tsx
+++ b/src/components/ComboBox.tsx
@@ -213,6 +213,10 @@ export function ComboBoxRenderFunction<T extends HTMLElement>(
     );
 }
 
-export const ComboBox = forwardRef<HTMLDivElement, ComboBoxProps<HTMLElement>>(ComboBoxRenderFunction);
+type CustomForwardRefResult = <T extends HTMLElement>(
+    props: React.PropsWithoutRef<ComboBoxProps<T>> & React.RefAttributes<HTMLDivElement>,
+) => React.ReactElement;
+
+export const ComboBox = forwardRef(ComboBoxRenderFunction) as CustomForwardRefResult;
 
 export default ComboBox;

--- a/src/components/FormMultiInput.tsx
+++ b/src/components/FormMultiInput.tsx
@@ -55,7 +55,7 @@ const StyledInput = styled(Input)`
     min-width: 100px;
 `;
 
-const StyledComboBox = styled(ComboBox)`
+const StyledComboBox = styled(ComboBox<HTMLButtonElement>)`
     margin-left: ${gapS};
 `;
 


### PR DESCRIPTION
Returns generic type for <ComboBox /> component


## PR includes

- [x] Bug Fix

## Related issues

Resolve #257 

## QA Instructions, Screenshots, Recordings

Now for each usage of component need cast type of trigger ref
```ts

<ComboBox<HTMLSpanElement>
    renderTrigger={(props) => <span ref={props.ref}} />}
    ...
/>

// or

const StyledComboBox = styled(ComboBox<HTMLSpanElement>)``;

<StyledComboBox
    renderTrigger={(props) => <span ref={props.ref}} />}
    ...
/>
