### PR TITLE
Drop useless `value` prop in `Spinner` component

### DIFF
--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -24,7 +24,7 @@ const StyledLoaderIcon = styled(IconLoaderOutline)`
     transform: translate3d(-50%, -50%, 0);
 `;
 
-export interface SpinnerProps extends BaseIconProps {
+export interface SpinnerProps extends Omit<BaseIconProps, 'value'> {
     animationDuration?: number; // in seconds
 }
 


### PR DESCRIPTION
## PR includes

- [x] Bug Fix

## Related issues

Resolve #547 