### PR TITLE
Harmony: button should not include both icons without text props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "4.5.2",
-        "@taskany/colors": "1.5.0",
+        "@taskany/colors": "1.7.0",
         "@taskany/icons": "2.0.1",
         "@tippyjs/react": "4.2.6",
         "classnames": "2.3.2",
@@ -7014,9 +7014,9 @@
       "dev": true
     },
     "node_modules/@taskany/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@taskany/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-8WK1q0Pc/gWwGPD+V9WVTqQNR9MsC12vLVlzfUrJB/oMtF26OeJanVYW92U+b98BzJBSrkaEUgdR2cimtBQ+9Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@taskany/colors/-/colors-1.7.0.tgz",
+      "integrity": "sha512-5V6gS6N4B5X9w702UKZIHlKWu6Ca1brfxXONz9S92r5V7DrD9K3EnTE3h3xAgDiu8T9Vhd96FUTWrhi2HKFjqQ==",
       "peerDependencies": {
         "styled-components": "^5.3.11"
       }
@@ -25792,9 +25792,9 @@
       "dev": true
     },
     "@taskany/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@taskany/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-8WK1q0Pc/gWwGPD+V9WVTqQNR9MsC12vLVlzfUrJB/oMtF26OeJanVYW92U+b98BzJBSrkaEUgdR2cimtBQ+9Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@taskany/colors/-/colors-1.7.0.tgz",
+      "integrity": "sha512-5V6gS6N4B5X9w702UKZIHlKWu6Ca1brfxXONz9S92r5V7DrD9K3EnTE3h3xAgDiu8T9Vhd96FUTWrhi2HKFjqQ==",
       "requires": {}
     },
     "@taskany/eslint-plugin-rules": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "4.5.2",
-    "@taskany/colors": "1.5.0",
+    "@taskany/colors": "1.7.0",
     "@taskany/icons": "2.0.1",
     "@tippyjs/react": "4.2.6",
     "classnames": "2.3.2",

--- a/src/harmony/Button/Button.tsx
+++ b/src/harmony/Button/Button.tsx
@@ -38,6 +38,11 @@ interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'chi
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ className, iconLeft, iconRight, text, view = 'default', brick, size = 's', ...rest }, ref) => {
         const icons = [iconLeft, iconRight].filter(Boolean);
+
+        if (!text && icons.length === 2) {
+            throw new Error("Button can't have two icons without text");
+        }
+
         const classes = [
             s.Button,
             viewMap[view],


### PR DESCRIPTION
## PR includes

- [x] Bug Fix

## Related issues

Resolve #694 

