### PR TITLE
Harmony: update Dropdown

### DIFF
--- a/src/harmony/Badge/Badge.module.css
+++ b/src/harmony/Badge/Badge.module.css
@@ -12,11 +12,13 @@
 .BadgeIconLeft {
     margin-right: var(--gap-s);
     display: inline-flex;
+    line-height: 1;
 }
 
 .BadgeIconRight {
     margin-left: var(--gap-s);
     display: inline-flex;
+    line-height: 1;
 }
 
 .BadgeSizeS {

--- a/src/harmony/DatePicker/DatePicker.module.css
+++ b/src/harmony/DatePicker/DatePicker.module.css
@@ -42,7 +42,7 @@
     justify-content: space-between;
 }
 
-.DatePickerHintIcon {
+.DatePickerHintIcon.DatePickerHintIcon {
     color: var(--gray-900);
     background-color: var(--text-secondary);
 
@@ -53,6 +53,7 @@
     font-size: var(--font-size-xs);
     cursor: pointer;
     border-bottom: 1px dotted currentColor;
+    margin-left: auto;
 }
 
 .DatePickerInlineWrapper {
@@ -103,8 +104,8 @@
     padding: var(--gap-s);
     width: 100%;
     background-color: var(--gray-900);
-    display: inline-block;
-    vertical-align: middle;
-    text-align: left;
+    display: flex;
+    align-items: center;
+    justify-content: start;
     border-radius: var(--radius-m);
 }

--- a/src/harmony/DatePicker/DatePicker.tsx
+++ b/src/harmony/DatePicker/DatePicker.tsx
@@ -36,8 +36,8 @@ interface DatePickerValue {
 interface DatePickerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
     value?: DatePickerValue;
     translates: {
-        hint: string;
-        reset: string;
+        hint?: string;
+        reset?: string;
         warning?: string;
     };
     onChange: (val?: DatePickerValue) => void;
@@ -485,13 +485,18 @@ export const DatePicker: React.FC<React.PropsWithChildren<DatePickerProps>> = ({
             <div className={classNames(classes.DatePicker, className)} {...attrs}>
                 {children}
                 <div className={classes.DatePickerFooter}>
-                    <Tooltip
-                        target={<IconQuestionCircleSolid size="s" className={classes.DatePickerHintIcon} />}
-                        placement="top"
-                        offset={[10, 10]}
-                    >
-                        {translates.hint}
-                    </Tooltip>
+                    {nullable(translates.hint, (hint) => (
+                        <Tooltip
+                            target={<IconQuestionCircleSolid size={20} className={classes.DatePickerHintIcon} />}
+                            placement="top"
+                            offset={[10, 10]}
+                            maxWidth={180}
+                            minWidth={180}
+                            interactive
+                        >
+                            {hint}
+                        </Tooltip>
+                    ))}
 
                     {nullable(value, () => (
                         <Link className={classes.DatePickerResetControl} onClick={onReset} view="secondary">
@@ -504,6 +509,7 @@ export const DatePicker: React.FC<React.PropsWithChildren<DatePickerProps>> = ({
                         className={classes.DatePickerWarningMessage}
                         iconLeft={<IconExclamationCircleSolid size="s" />}
                         text={warnText}
+                        weight="regular"
                     />
                 ))}
             </div>

--- a/src/harmony/Dropdown/Dropdown.module.css
+++ b/src/harmony/Dropdown/Dropdown.module.css
@@ -1,49 +1,144 @@
 .DropdownTrigger {
-    border: 1px solid transparent;
-    padding: var(--gap-xs) var(--gap-sm);
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.125rem;
+
+    padding-left: var(--gap-xs);
+    padding-right: var(--gap-s);
+
+    width: 100%;
+    min-height: var(--gap-l);
     box-sizing: border-box;
+
+    border: 1px solid transparent;
+    border-radius: var(--radius-m);
+
+    transition: var(--transition-time) var(--transition-func);
+    transition-property: color, background-color, border-color;
+
+    user-select: none;
 }
 
-.DropdownTriggerOutline {
-    border-radius: 10px;
+.DropdownTriggerWithLabel {
+    height: 50px;
+    padding-top: var(--gap-xs);
+    padding-bottom: var(--gap-xs);
+}
+
+.DropdownTrigger:focus {
+    outline: none;
+}
+
+.DropdownTrigger:hover {
+    cursor: pointer;
+}
+
+.DropdownTrigger:focus-visible {
+    outline: 2px solid var(--gray-500);
+}
+
+.DropdownTrigger_view_default:hover {
+    background-color: var(--base-hover);
+}
+
+.DropdownTrigger_view_default:active,
+.DropdownTrigger_view_default.DropdownTrigger_active {
+    background-color: var(--button-secondary-active);
+}
+
+.DropdownTrigger_view_outline {
+    border-color: var(--gray-800);
+}
+
+.DropdownTrigger_view_outline:hover {
+    border-color: var(--gray-700);
+}
+
+.DropdownTrigger_view_outline:active,
+.DropdownTrigger_view_outline.DropdownTrigger_active {
+    border-color: var(--gray-600);
+}
+
+.DropdownTrigger_view_fill {
+    background-color: var(--button-secondary);
+}
+
+.DropdownTrigger_view_fill:hover {
+    background-color: var(--button-secondary-hover);
+}
+
+.DropdownTrigger_view_fill:active,
+.DropdownTrigger_view_fill.DropdownTrigger_active {
+    background-color: var(--button-secondary-active);
+}
+
+.DropdownTrigger.DropdownTrigger_disabled {
+    background-color: transparent;
+    color: var(--text-ghost);
+    cursor: not-allowed;
+}
+
+.DropdownTrigger_view_outline.DropdownTrigger_disabled {
     border-color: var(--base-hover);
 }
 
-.DropdownTriggerLabel {
-    display: flex;
-    margin-bottom: 0.125rem;
-    color: var(--text-ghost);
-    font-size: var(--font-size-xs);
-    line-height: 1rem;
-    align-items: center;
-    justify-content: flex-start;
+.DropdownTrigger_view_fill.DropdownTrigger_disabled {
+    background-color: var(--button-secondary);
 }
 
-.DropdownTriggerControl {
-    display: flex;
+.DropdownTrigger.DropdownTrigger_readOnly {
+    background-color: transparent;
+    color: var(--text-secondary);
+    cursor: default;
+}
+
+.DropdownTrigger_view_outline.DropdownTrigger_readOnly {
+    border-color: var(--base-hover);
+}
+
+.DropdownTrigger_view_fill.DropdownTrigger_readOnly {
+    background-color: var(--button-secondary);
+}
+
+.DropdownTriggerLabel {
     width: 100%;
-    flex-wrap: nowrap;
+    padding: 0 var(--gap-s);
+    box-sizing: border-box;
+    color: var(--text-ghost);
+}
+
+.DropdownTrigger_view_fill .DropdownTriggerLabel {
+    color: var(--text-secondary);
+}
+
+.DropdownTriggerValueWrapper {
+    display: flex;
     align-items: center;
+    justify-content: space-between;
+    flex: 1;
 }
 
 .DropdownTriggerValue {
-    display: flex;
-    flex: 1;
-    align-items: center;
-    justify-content: flex-start;
-    line-height: 1.5rem;
-    width: inherit;
-}
-
-.DropdownTriggerIcon {
-    margin-left: auto;
-    display: inline-flex;
-}
-
-.DropdownTriggerLabel .DropdownTriggerIcon {
-    margin-left: unset;
+    width: 100%;
+    padding: 0 var(--gap-s);
 }
 
 .DropdownPanel {
     box-sizing: border-box;
+}
+
+.DropdownTrigger_error,
+.DropdownTrigger_error:hover,
+.DropdownTrigger_error:active {
+    background-color: var(--danger-900);
+    color: var(--danger-400);
+}
+
+.DropdownTrigger_error_outline {
+    border-color: var(--danger-500);
+}
+
+.DropdownTriggerLabel_error {
+    color: var(--danger-600);
 }

--- a/src/harmony/Dropdown/Dropdown.stories.tsx
+++ b/src/harmony/Dropdown/Dropdown.stories.tsx
@@ -1,165 +1,64 @@
-import React, { useState } from 'react';
+import React, { ComponentProps, useState } from 'react';
 import { StoryFn, Meta } from '@storybook/react';
 
-import { nullable } from '../../utils';
+import { Text } from '../Text/Text';
+import { Table, TableCell, TableRow } from '../Table/Table';
 
-import { Dropdown, DropdownPanel, DropdownTrigger } from './Dropdown';
+import { Dropdown as DropdownProvider, DropdownPanel, DropdownTrigger } from './Dropdown';
 
-type Story = StoryFn<typeof Dropdown>;
+type Story = StoryFn<typeof DropdownProvider>;
 
-const story: Meta<typeof Dropdown> = {
+const story: Meta<typeof DropdownProvider> = {
     title: '@harmony/Dropdown',
-    component: Dropdown,
+    component: DropdownProvider,
     args: {},
 };
 
 export default story;
 
-const itemStyles: React.CSSProperties = {
-    width: '100%',
-    whiteSpace: 'nowrap',
-    wordBreak: 'break-all',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-};
+const text =
+    'Lorem ipsum dolor sit amet consectetur adipisicing elit. In asperiores laboriosam, ipsum esse cum dolorem exercitationem molestiae.';
 
-const Item: React.FC<React.PropsWithChildren<{ muted?: boolean; onClick?: () => void }>> = ({
-    muted,
-    children,
-    onClick,
-}) => {
+const Dropdown = ({ view, error }: { view?: ComponentProps<typeof DropdownTrigger>['view']; error?: boolean }) => {
+    const [isOpen, setIsOpen] = useState(false);
     return (
-        <div onClick={onClick} style={{ color: muted ? 'var(--gray-700)' : 'var(--gray-300)', ...itemStyles }}>
-            {children}
-        </div>
+        <DropdownProvider isOpen={isOpen} onClose={() => setIsOpen(false)}>
+            <DropdownTrigger onClick={() => setIsOpen(true)} view={view} error={error}>
+                <Text size="s">Q4/2023</Text>
+            </DropdownTrigger>
+            <DropdownPanel width={200}>{text}</DropdownPanel>
+        </DropdownProvider>
     );
 };
 
-const List: React.FC<React.PropsWithChildren> = ({ children }) => {
-    return <div style={{ padding: '0 var(--gap-xs)' }}>{children}</div>;
-};
+const views = ['default', 'outline', 'fill'] as const;
 
-const data = Array.from({ length: 10 }, (_, i) => ({
-    id: i + 1,
-    title: `Very longest item title ${i + 1}`,
-}));
-
-export const Default: Story = (args) => {
-    const [selected, setSelected] = useState<string | null>(null);
+export const Default: Story = () => {
     return (
-        <Dropdown {...args}>
-            <DropdownTrigger label="Item" style={{ width: '200px' }}>
-                {nullable(
-                    selected,
-                    (value) => (
-                        <Item>{value}</Item>
-                    ),
-                    <Item muted>No selected</Item>,
-                )}
-            </DropdownTrigger>
-            <DropdownPanel style={{ width: '200px' }}>
-                <List>
-                    {data.map((val) => (
-                        <Item
-                            key={String(val.id)}
-                            muted={selected !== val.title}
-                            onClick={() => setSelected(val.title)}
-                        >
-                            {val.title}
-                        </Item>
+        <>
+            <Table>
+                <TableRow>
+                    {views.map((view) => (
+                        <TableCell style={{ flex: 1 }}>
+                            <Text weight="bold">{view}</Text>
+                        </TableCell>
                     ))}
-                </List>
-            </DropdownPanel>
-        </Dropdown>
-    );
-};
-
-export const Outlined: Story = (args) => {
-    const [selected, setSelected] = useState<string | null>(null);
-    return (
-        <Dropdown {...args}>
-            <DropdownTrigger label="Item" view="outline" style={{ width: '200px' }}>
-                {nullable(
-                    selected,
-                    (value) => (
-                        <Item>{value}</Item>
-                    ),
-                    <Item muted>No selected</Item>,
-                )}
-            </DropdownTrigger>
-            <DropdownPanel style={{ width: '200px' }}>
-                <List>
-                    {data.map((val) => (
-                        <Item
-                            key={String(val.id)}
-                            muted={selected !== val.title}
-                            onClick={() => setSelected(val.title)}
-                        >
-                            {val.title}
-                        </Item>
+                </TableRow>
+                <TableRow>
+                    {views.map((view) => (
+                        <TableCell>
+                            <Dropdown view={view} />
+                        </TableCell>
                     ))}
-                </List>
-            </DropdownPanel>
-        </Dropdown>
-    );
-};
-
-export const DefaultWoLabel: Story = (args) => {
-    const [selected, setSelected] = useState<string | null>(null);
-    return (
-        <Dropdown {...args}>
-            <DropdownTrigger style={{ width: '200px' }}>
-                {nullable(
-                    selected,
-                    (value) => (
-                        <Item>{value}</Item>
-                    ),
-                    <Item muted>No selected</Item>,
-                )}
-            </DropdownTrigger>
-            <DropdownPanel style={{ width: '200px' }}>
-                <List>
-                    {data.map((val) => (
-                        <Item
-                            key={String(val.id)}
-                            muted={selected !== val.title}
-                            onClick={() => setSelected(val.title)}
-                        >
-                            {val.title}
-                        </Item>
+                </TableRow>
+                <TableRow>
+                    {views.map((view) => (
+                        <TableCell>
+                            <Dropdown view={view} error />
+                        </TableCell>
                     ))}
-                </List>
-            </DropdownPanel>
-        </Dropdown>
-    );
-};
-
-export const OutlinedWoLabel: Story = (args) => {
-    const [selected, setSelected] = useState<string | null>(null);
-    return (
-        <Dropdown {...args}>
-            <DropdownTrigger view="outline" style={{ width: '200px' }}>
-                {nullable(
-                    selected,
-                    (value) => (
-                        <Item>{value}</Item>
-                    ),
-                    <Item muted>No selected</Item>,
-                )}
-            </DropdownTrigger>
-            <DropdownPanel style={{ width: '200px' }}>
-                <List>
-                    {data.map((val) => (
-                        <Item
-                            key={String(val.id)}
-                            muted={selected !== val.title}
-                            onClick={() => setSelected(val.title)}
-                        >
-                            {val.title}
-                        </Item>
-                    ))}
-                </List>
-            </DropdownPanel>
-        </Dropdown>
+                </TableRow>
+            </Table>
+        </>
     );
 };


### PR DESCRIPTION
Added `view` prop options (`default`, `outline`, `fill`) and new props `readonly` and `disabled` to the dropdown component. 
Modified API to require passing `isOpen` from external sources.


## PR includes

- [x] Refactor

## Related issues

Resolve #894 

Related issue: 
- https://github.com/taskany-inc/issues/pull/2325

## QA Instructions, Screenshots, Recordings
  

https://github.com/taskany-inc/bricks/assets/95316053/b6670cc1-6c4b-4277-b16f-d7877adbd93e

