### PR TITLE
fix(INTERNAL-2620): close drawer on outside click

### DIFF
--- a/src/harmony/Drawer/Drawer.tsx
+++ b/src/harmony/Drawer/Drawer.tsx
@@ -14,6 +14,7 @@ interface DrawerProps {
     className?: string;
     animated?: boolean;
     onClose?: () => void;
+    closeOnClickOutside?: boolean;
 }
 
 const DrawerContext = React.createContext<Partial<{ onClose(): void }>>({
@@ -36,12 +37,30 @@ export const Drawer: React.FC<React.PropsWithChildren<DrawerProps>> = ({
     children,
     onClose,
     className,
+    closeOnClickOutside = false,
 }) => {
     const drawerRef = useRef<HTMLDivElement>(null);
     const [opened, setOpened] = useState(false);
     const [onESC] = useKeyboard([KeyCode.Escape], () => onClose?.(), {
         disableGlobalEvent: false,
     });
+
+    useEffect(() => {
+        if (!onClose || !visible || !closeOnClickOutside) return;
+
+        const handleClickOutside = (event: MouseEvent) => {
+            const target = event.target as Node;
+            if (drawerRef.current && !drawerRef.current.contains(target)) {
+                onClose();
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [onClose, visible, closeOnClickOutside]);
 
     const performState = useCallback((condition: boolean, classes: [string, string]) => {
         if (drawerRef.current == null) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/taskany-inc/issues/blob/main/CONTRIBUTING.md;
     - 📖 Read the Forem Code of Conduct: https://github.com/taskany-inc/issues/blob/main/CODE_OF_CONDUCT.md;
     - 👷‍♀️ Create small PRs. in most cases this will be possible;
     - ✅ Provide tests for your changes;
     - 📝 Use conventional commit messages: https://www.conventionalcommits.org/en/v1.0.0/;
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Taskany Team member before any CI builds will run.
-->

## PR includes

- [x] Bug Fix

## Related issues

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolve #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

Resolve #2827

Related issues #2620

## QA Instructions, Screenshots, Recordings
  
before:

https://github.com/user-attachments/assets/bc7637fb-23f1-4ce3-a3ba-ce4194ea944a

after:

https://github.com/user-attachments/assets/1872bbad-2bf5-4a83-8d90-e8746a0b63dc

<!-- THANKS FOR YOUR CONTRIBUTION -->
